### PR TITLE
Add 16-bit usize support.

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -136,6 +136,13 @@ impl LookupReverse<u64> for u64 {
 
 impl LookupReverse<usize> for usize {
     #[inline]
+    #[cfg(target_pointer_width = "16")]
+    fn swap_bits(self) -> usize {
+        use LookupReverse;
+        LookupReverse::swap_bits(self as u16) as usize
+    }
+    
+    #[inline]
     #[cfg(target_pointer_width = "32")]
     fn swap_bits(self) -> usize {
         use LookupReverse;


### PR DESCRIPTION
I needed `bit_reverse` for msp430, a 16-bit architecture, so I went ahead and added 16-bit `usize` support. Compiles fine now w/ `no_std` :).