### PR TITLE
Remove type parameter

### DIFF
--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -1,13 +1,13 @@
 use super::core;
 
 /// Computes bit reversal by going bit by bit and setting the reverse position bit for the output.
-pub trait BitwiseReverse<T> {
+pub trait BitwiseReverse {
     /// Swaps the bits such that bit i is now bit N-i, where N is the length of the T in bits.
-    fn swap_bits(self) -> T;
+    fn swap_bits(self) -> Self;
 }
 
 macro_rules! doit_bitwise { ($($ty:ty),*) => ($(
-    impl BitwiseReverse<$ty> for $ty {
+    impl BitwiseReverse for $ty {
         // This algorithm uses the reverse variable as a like a stack to reverse the value.
         // The lesser significant bits are pushed onto the reverse variable and then the variable
         // is shifted down to make room for more significant bits. This algorithm has a shortcut,

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,9 +1,8 @@
-
 /// Computes bit reversal by using lookup table to translate a single byte into its reverse.
 /// For multi-byte types, the byte order is swapped to complete the reversal.
-pub trait LookupReverse<T> {
+pub trait LookupReverse {
     /// Swaps the bits such that bit i is now bit N-i, where N is the length of the T in bits.
-    fn swap_bits(self) -> T;
+    fn swap_bits(self) -> Self;
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -26,14 +25,14 @@ const REVERSE_LOOKUP: [u8; 256] = [
     15, 143, 79, 207, 47, 175, 111, 239, 31, 159, 95, 223, 63, 191, 127, 255
 ];
 
-impl LookupReverse<u8> for u8 {
+impl LookupReverse for u8 {
     #[inline]
     fn swap_bits(self) -> u8 {
         REVERSE_LOOKUP[self as usize]
     }
 }
 
-impl LookupReverse<u16> for u16 {
+impl LookupReverse for u16 {
     #[inline]
     fn swap_bits(self) -> u16 {
         (REVERSE_LOOKUP[self as u8 as usize] as u16) << 8 |
@@ -41,7 +40,7 @@ impl LookupReverse<u16> for u16 {
     }
 }
 
-impl LookupReverse<u32> for u32 {
+impl LookupReverse for u32 {
     #[inline]
     fn swap_bits(self) -> u32 {
         (REVERSE_LOOKUP[self as u8 as usize] as u32) << 24 |
@@ -51,7 +50,7 @@ impl LookupReverse<u32> for u32 {
     }
 }
 
-impl LookupReverse<u64> for u64 {
+impl LookupReverse for u64 {
     #[inline]
     fn swap_bits(self) -> u64 {
         (REVERSE_LOOKUP[self as u8 as usize] as u64) << 56 |
@@ -65,7 +64,7 @@ impl LookupReverse<u64> for u64 {
     }
 }
 
-impl LookupReverse<usize> for usize {
+impl LookupReverse for usize {
     #[inline]
     #[cfg(target_pointer_width = "8")]
     fn swap_bits(self) -> usize {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,34 +1,34 @@
 macro_rules! doit_signed {
     ($($Algo:ident),*) => ($(
-        impl $Algo<i8> for i8 {
+        impl $Algo for i8 {
             #[inline]
             fn swap_bits(self) -> i8 {
                 $Algo::swap_bits(self as u8) as i8
             }
         }
 
-        impl $Algo<i16> for i16 {
+        impl $Algo for i16 {
             #[inline]
             fn swap_bits(self) -> i16 {
                 $Algo::swap_bits(self as u16) as i16
             }
         }
 
-        impl $Algo<i32> for i32 {
+        impl $Algo for i32 {
             #[inline]
             fn swap_bits(self) -> i32 {
                 $Algo::swap_bits(self as u32) as i32
             }
         }
 
-        impl $Algo<i64> for i64 {
+        impl $Algo for i64 {
             #[inline]
             fn swap_bits(self) -> i64 {
                 $Algo::swap_bits(self as u64) as i64
             }
         }
 
-        impl $Algo<isize> for isize {
+        impl $Algo for isize {
             #[inline]
             fn swap_bits(self) -> isize {
                 $Algo::swap_bits(self as usize) as isize

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,13 +1,13 @@
 /// Computes bit reversal by using a divide and conquer approach. Pairs of bits are swapped.
 /// Then neighboring bit pairs are swapped. Each time swapping the next largest group of bits.
 /// This is done until the entire data has been bit reversed.
-pub trait ParallelReverse<T> {
+pub trait ParallelReverse {
     /// Swaps the bits such that bit i is now bit N-i, where N is the length of the T in bits.
-    fn swap_bits(self) -> T;
+    fn swap_bits(self) -> Self;
 }
 
 macro_rules! doit_parallel { ($($ty:ty),*) => ($(
-    impl ParallelReverse<$ty> for $ty {
+    impl ParallelReverse for $ty {
         #[inline]
         fn swap_bits(self) -> $ty {
             let mut v = self;


### PR DESCRIPTION
Bit reversal should not be parametrized. Each type that implements the trait should return the same type after the bit swap.